### PR TITLE
Check code formatting before executing specs

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -21,7 +21,12 @@ def build_app
 end
 
 def test_app
-  system("cd app && crystal spec")
+  formatted? = system("cd app && crystal tool format --check")
+  if formatted?
+    system("cd app && crystal spec")
+  else
+    formatted?
+  end
 end
 
 def cleanup


### PR DESCRIPTION
This will check code formatting before executing spec (fail fast)

Related: https://github.com/amberframework/amber/pull/797