### PR TITLE
Update documentation links

### DIFF
--- a/basic/crecto/app/README.md.lqd
+++ b/basic/crecto/app/README.md.lqd
@@ -8,7 +8,7 @@ This is a project written using [Amber](https://amberframework.org). Enjoy!
 
 These instructions will get a copy of this project running on your machine for development and testing purposes.
 
-Please see [deployment](https://amberframework.gitbook.io/amber/deployment) for notes on deploying the project in production.
+Please see [deployment](https://docs.amberframework.org/amber/deployment) for notes on deploying the project in production.
 
 ## Prerequisites
 
@@ -20,14 +20,14 @@ To start your Amber server:
 
 1. Install dependencies with `shards install`
 2. Build executables with `shards build`
-3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://amberframework.gitbook.io/amber/guides/create-new-app#creating-the-database).
+3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://docs.amberframework.org/amber/guides/create-new-app#creating-the-database).
 4. Start Amber server with `bin/amber watch`
 
 Now you can visit http://localhost:3000/ from your browser.
 
-Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://amberframework.gitbook.io/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
+Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://docs.amberframework.org/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
 
-Using Docker? Please check [Amber Docker guides](https://amberframework.gitbook.io/amber/guides/docker).
+Using Docker? Please check [Amber Docker guides](https://docs.amberframework.org/amber/guides/docker).
 
 ## Tests
 

--- a/basic/granite/app/README.md.lqd
+++ b/basic/granite/app/README.md.lqd
@@ -8,7 +8,7 @@ This is a project written using [Amber](https://amberframework.org). Enjoy!
 
 These instructions will get a copy of this project running on your machine for development and testing purposes.
 
-Please see [deployment](https://amberframework.gitbook.io/amber/deployment) for notes on deploying the project in production.
+Please see [deployment](https://docs.amberframework.org/amber/deployment) for notes on deploying the project in production.
 
 ## Prerequisites
 
@@ -20,14 +20,14 @@ To start your Amber server:
 
 1. Install dependencies with `shards install`
 2. Build executables with `shards build`
-3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://amberframework.gitbook.io/amber/guides/create-new-app#creating-the-database).
+3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://docs.amberframework.org/amber/guides/create-new-app#creating-the-database).
 4. Start Amber server with `bin/amber watch`
 
 Now you can visit http://localhost:3000/ from your browser.
 
-Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://amberframework.gitbook.io/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
+Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://docs.amberframework.org/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
 
-Using Docker? Please check [Amber Docker guides](https://amberframework.gitbook.io/amber/guides/docker).
+Using Docker? Please check [Amber Docker guides](https://docs.amberframework.org/amber/guides/docker).
 
 ## Tests
 

--- a/default/app/README.md.lqd
+++ b/default/app/README.md.lqd
@@ -8,7 +8,7 @@ This is a project written using [Amber](https://amberframework.org). Enjoy!
 
 These instructions will get a copy of this project running on your machine for development and testing purposes.
 
-Please see [deployment](https://amberframework.gitbook.io/amber/deployment) for notes on deploying the project in production.
+Please see [deployment](https://docs.amberframework.org/amber/deployment) for notes on deploying the project in production.
 
 ## Prerequisites
 
@@ -20,14 +20,14 @@ To start your Amber server:
 
 1. Install dependencies with `shards install`
 2. Build executables with `shards build`
-3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://amberframework.gitbook.io/amber/guides/create-new-app#creating-the-database).
+3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://docs.amberframework.org/amber/guides/create-new-app#creating-the-database).
 4. Start Amber server with `bin/amber watch`
 
 Now you can visit http://localhost:3000/ from your browser.
 
-Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://amberframework.gitbook.io/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
+Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://docs.amberframework.org/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
 
-Using Docker? Please check [Amber Docker guides](https://amberframework.gitbook.io/amber/guides/docker).
+Using Docker? Please check [Amber Docker guides](https://docs.amberframework.org/amber/guides/docker).
 
 ## Tests
 

--- a/misc/modular/app/README.md.lqd
+++ b/misc/modular/app/README.md.lqd
@@ -8,7 +8,7 @@ This is a project written using [Amber](https://amberframework.org). Enjoy!
 
 These instructions will get a copy of this project running on your machine for development and testing purposes.
 
-Please see [deployment](https://amberframework.gitbook.io/amber/deployment) for notes on deploying the project in production.
+Please see [deployment](https://docs.amberframework.org/amber/deployment) for notes on deploying the project in production.
 
 ## Prerequisites
 
@@ -20,14 +20,14 @@ To start your Amber server:
 
 1. Install dependencies with `shards install`
 2. Build executables with `shards build`
-3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://amberframework.gitbook.io/amber/guides/create-new-app#creating-the-database).
+3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://docs.amberframework.org/amber/guides/create-new-app#creating-the-database).
 4. Start Amber server with `bin/amber watch`
 
 Now you can visit http://localhost:3000/ from your browser.
 
-Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://amberframework.gitbook.io/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
+Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://docs.amberframework.org/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
 
-Using Docker? Please check [Amber Docker guides](https://amberframework.gitbook.io/amber/guides/docker).
+Using Docker? Please check [Amber Docker guides](https://docs.amberframework.org/amber/guides/docker).
 
 ## Tests
 

--- a/react/preact_redux/app/README.md.lqd
+++ b/react/preact_redux/app/README.md.lqd
@@ -8,7 +8,7 @@ This is a project written using [Amber](https://amberframework.org). Enjoy!
 
 These instructions will get a copy of this project running on your machine for development and testing purposes.
 
-Please see [deployment](https://amberframework.gitbook.io/amber/deployment) for notes on deploying the project in production.
+Please see [deployment](https://docs.amberframework.org/amber/deployment) for notes on deploying the project in production.
 
 ## Prerequisites
 
@@ -20,14 +20,14 @@ To start your Amber server:
 
 1. Install dependencies with `shards install`
 2. Build executables with `shards build`
-3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://amberframework.gitbook.io/amber/guides/create-new-app#creating-the-database).
+3. Create and migrate your database with `bin/amber db create migrate`. Also see [creating the database](https://docs.amberframework.org/amber/guides/create-new-app#creating-the-database).
 4. Start Amber server with `bin/amber watch`
 
 Now you can visit http://localhost:3000/ from your browser.
 
-Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://amberframework.gitbook.io/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
+Getting an error message you need help decoding? Check the [Amber troubleshooting guide](https://docs.amberframework.org/amber/troubleshooting), post a [tagged message on Stack Overflow](https://stackoverflow.com/questions/tagged/amber-framework), or visit [Amber on Gitter](https://gitter.im/amberframework/amber).
 
-Using Docker? Please check [Amber Docker guides](https://amberframework.gitbook.io/amber/guides/docker).
+Using Docker? Please check [Amber Docker guides](https://docs.amberframework.org/amber/guides/docker).
 
 ## Tests
 


### PR DESCRIPTION
Hi @damianham @imdrasil ! :smile: 

This PR changes `amberframework.gitbook.io` to our new `docs.amberframework.org`