### PR TITLE
Fixes Repo.get hack

### DIFF
--- a/basic/crecto/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.lqd
+++ b/basic/crecto/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.lqd
@@ -19,8 +19,7 @@ end
 def create_{{ name | underscore }}
   model = {{ class_name }}.new
   model.update_from_hash({{ name | underscore }}_hash)
-  Repo.insert(model)
-  Repo.get({{ class_name }}, 1).not_nil!
+  Repo.insert(model).instance
 end
 
 class {{ class_name }}ControllerTest < GarnetSpec::Controller::Test

--- a/default/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.lqd
+++ b/default/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.lqd
@@ -20,8 +20,7 @@ def create_{{ name | underscore }}
   {% if model == "crecto" -%}
   model = {{ class_name }}.new
   model.update_from_hash({{ name | underscore }}_hash)
-  Repo.insert(model)
-  Repo.get({{ class_name }}, 1).not_nil!
+  Repo.insert(model).instance
 {% else -%}
   model = {{ class_name }}.new({{ name | underscore }}_hash)
   model.save

--- a/misc/modular/scaffold/controller/spec/modules/{{name}}/{{name}}_controller_spec.cr.lqd
+++ b/misc/modular/scaffold/controller/spec/modules/{{name}}/{{name}}_controller_spec.cr.lqd
@@ -20,8 +20,7 @@ def create_{{ name | underscore }}
   {% if model == "crecto" -%}
   model = {{ class_name }}.new
   model.update_from_hash({{ name | underscore }}_hash)
-  Repo.insert(model)
-  Repo.get({{ class_name }}, 1).not_nil!
+  Repo.insert(model).instance
 {% else -%}
   model = {{ class_name }}.new({{ name | underscore }}_hash)
   model.save

--- a/react/preact_redux/scaffold/controller/spec/modules/{{name}}/{{name}}_controller_spec.cr.lqd
+++ b/react/preact_redux/scaffold/controller/spec/modules/{{name}}/{{name}}_controller_spec.cr.lqd
@@ -20,8 +20,7 @@ def create_{{ name | underscore }}
   {% if model == "crecto" -%}
   model = {{ class_name }}.new
   model.update_from_hash({{ name | underscore }}_hash)
-  Repo.insert(model)
-  Repo.get({{ class_name }}, 1).not_nil!
+  Repo.insert(model).instance
 {% else -%}
   model = {{ class_name }}.new({{ name | underscore }}_hash)
   model.save


### PR DESCRIPTION
Replaces `Repo.get({{ class_name }}, 1).not_nil!` by `Repo.insert(model).instance`